### PR TITLE
Web client upgrade

### DIFF
--- a/src/bgTeam.Web/Impl/WebClient.cs
+++ b/src/bgTeam.Web/Impl/WebClient.cs
@@ -1,20 +1,19 @@
 ﻿namespace bgTeam.Web.Impl
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Net;
+    using System.Net.Http;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Threading.Tasks;
+    using System.Web;
     using bgTeam;
     using bgTeam.Extensions;
     using bgTeam.Web;
     using bgTeam.Web.Builders;
     using bgTeam.Web.Exceptions;
     using Newtonsoft.Json;
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Security.Cryptography.X509Certificates;
-    using System.Threading.Tasks;
-    using System.Web;
 
     public class WebClient : IWebClient
     {
@@ -193,7 +192,7 @@
 
         public string Url => _url;
 
-        public async Task<T> GetAsync<T>(string method, IDictionary<string, object> queryParams = null, IDictionary<string, object> headers = null)
+        public virtual async Task<T> GetAsync<T>(string method, IDictionary<string, object> queryParams = null, IDictionary<string, object> headers = null)
             where T : class
         {
             if (string.IsNullOrWhiteSpace(_url))
@@ -209,7 +208,7 @@
             return await ProcessResultAsync<T>(resultGet);
         }
 
-        public async Task<T> PostAsync<T>(string method, object postParams = null, IDictionary<string, object> headers = null)
+        public virtual async Task<T> PostAsync<T>(string method, object postParams = null, IDictionary<string, object> headers = null)
             where T : class
         {
             HttpContent content = null;

--- a/src/bgTeam.Web/Impl/WebClient.cs
+++ b/src/bgTeam.Web/Impl/WebClient.cs
@@ -314,14 +314,14 @@
             CheckResult(response);
 
             if (response.Content.Headers.ContentType != null
-                || string.Equals(response.Content.Headers.ContentType.CharSet, "utf8", StringComparison.OrdinalIgnoreCase))
+                && string.Equals(response.Content.Headers.ContentType.CharSet, "utf8", StringComparison.OrdinalIgnoreCase))
             {
                 response.Content.Headers.ContentType.CharSet = "utf-8";
             }
 
             var result = await response.Content.ReadAsStringAsync();
 
-            if (string.IsNullOrWhiteSpace(result) || result == "[]")
+            if (string.IsNullOrWhiteSpace(result))
             {
                 return default(T);
             }

--- a/tests/Test.bgTeam.Web/Test.bgTeam.Web.csproj
+++ b/tests/Test.bgTeam.Web/Test.bgTeam.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -10,6 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/tests/Test.bgTeam.Web/TestController.cs
+++ b/tests/Test.bgTeam.Web/TestController.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters.Json;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.bgTeam.Web
+{
+    [Route("[controller]/[action]")]
+    public class TestController : ControllerBase
+    {
+        [HttpGet]
+        public string GetString()
+        {
+            return "GetString";
+        }
+
+        [HttpPost]
+        public string PostString()
+        {
+            return "PostString";
+        }
+
+        [HttpPost]
+        public string PostNullString()
+        {
+            return null;
+        }
+
+        [HttpPost]
+        public IActionResult PostArrayString()
+        {
+            return new JsonResult(new string[] { "string1", "string2" });
+        }
+
+        [HttpPost]
+        public IActionResult PostEmptyArrayString()
+        {
+            return new JsonResult(new string[0]);
+        }
+    }
+}

--- a/tests/Test.bgTeam.Web/TestController.cs
+++ b/tests/Test.bgTeam.Web/TestController.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Globalization;
 
 namespace Test.bgTeam.Web
 {
@@ -40,6 +41,66 @@ namespace Test.bgTeam.Web
         public IActionResult PostEmptyArrayString()
         {
             return new JsonResult(new string[0]);
+        }
+
+        [HttpGet]
+        public string GetQueryString(string query)
+        {
+            return query;
+        }
+
+        [HttpGet]
+        public string GetQueryInt(int query)
+        {
+            return query.ToString(CultureInfo.InvariantCulture);
+        }
+
+        [HttpGet]
+        public string GetQueryDouble(double query)
+        {
+            return query.ToString(CultureInfo.InvariantCulture);
+        }
+
+        [HttpGet]
+        public string GetQueryDateTime(DateTime query)
+        {
+            return query.ToString(CultureInfo.InvariantCulture);
+        }
+
+        [HttpGet]
+        public string GetQueryDateTimeOffset(DateTimeOffset query)
+        {
+            return query.ToString(CultureInfo.InvariantCulture);
+        }
+
+        [HttpGet]
+        public string GetQueryTimeSpan(TimeSpan query)
+        {
+            return query.ToString("G", CultureInfo.InvariantCulture);
+        }
+
+        [HttpGet]
+        public string GetQueryFloat(float query)
+        {
+            return query.ToString(CultureInfo.InvariantCulture);
+        }
+
+        [HttpGet]
+        public string GetQueryDecimal(decimal query)
+        {
+            return query.ToString(CultureInfo.InvariantCulture);
+        }
+
+        [HttpGet]
+        public string GetReturnHeaderValue()
+        {
+            return Request.Headers["test_header"];
+        }
+
+        [HttpPost]
+        public string PostReturnHeaderValue()
+        {
+            return Request.Headers["test_header"];
         }
     }
 }

--- a/tests/Test.bgTeam.Web/WebClientUnitTests.cs
+++ b/tests/Test.bgTeam.Web/WebClientUnitTests.cs
@@ -3,13 +3,11 @@ using bgTeam.Impl;
 using bgTeam.Web.Impl;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.AspNetCore.Mvc.Formatters.Json;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -95,6 +93,151 @@ namespace Test.bgTeam.Web
 
             Assert.NotNull(result);
             Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task Get_QueryString_String()
+        {
+            var query = new Dictionary<string, object> { { "query", "stringQuery" } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            webClient.Culture = CultureInfo.InvariantCulture;
+            var result = await webClient.GetAsync<string>("Test/GetQueryString", query).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(query["query"], result);
+        }
+
+        [Fact]
+        public async Task Get_QueryString_Int()
+        {
+            var expected = 12345678;
+            var query = new Dictionary<string, object> { { "query", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            webClient.Culture = CultureInfo.InvariantCulture;
+            var result = await webClient.GetAsync<string>("Test/GetQueryInt", query).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString(CultureInfo.InvariantCulture), result);
+        }
+
+        [Fact]
+        public async Task Get_QueryString_Double()
+        {
+            var expected = 12345.678D;
+            var query = new Dictionary<string, object> { { "query", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            webClient.Culture = CultureInfo.InvariantCulture;
+            var result = await webClient.GetAsync<string>("Test/GetQueryDouble", query).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString(CultureInfo.InvariantCulture), result);
+        }
+
+        [Fact]
+        public async Task Get_QueryString_DateTime()
+        {
+            var expected = DateTime.Now;
+            var query = new Dictionary<string, object> { { "query", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            webClient.Culture = CultureInfo.InvariantCulture;
+            var result = await webClient.GetAsync<string>("Test/GetQueryDateTime", query).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString(CultureInfo.InvariantCulture), result);
+        }
+
+        [Fact]
+        public async Task Get_QueryString_DateTimeOffset()
+        {
+            var expected = DateTimeOffset.Now;
+            var query = new Dictionary<string, object> { { "query", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            webClient.Culture = CultureInfo.InvariantCulture;
+            var result = await webClient.GetAsync<string>("Test/GetQueryDateTimeOffset", query).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString(CultureInfo.InvariantCulture), result);
+        }
+
+        [Fact]
+        public async Task Get_QueryString_TimeSpan()
+        {
+            var expected = TimeSpan.FromMilliseconds(31241241124);
+            var query = new Dictionary<string, object> { { "query", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            webClient.Culture = CultureInfo.InvariantCulture;
+            var result = await webClient.GetAsync<string>("Test/GetQueryTimeSpan", query).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString("G", CultureInfo.InvariantCulture), result);
+        }
+
+        [Fact]
+        public async Task Get_QueryString_Float()
+        {
+            var expected = 123.45678F;
+            var query = new Dictionary<string, object> { { "query", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            webClient.Culture = CultureInfo.InvariantCulture;
+            var result = await webClient.GetAsync<string>("Test/GetQueryFloat", query).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString(CultureInfo.InvariantCulture), result);
+        }
+
+        [Fact]
+        public async Task Get_QueryString_Decimal()
+        {
+            var expected = 123.45678M;
+            var query = new Dictionary<string, object> { { "query", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            webClient.Culture = CultureInfo.InvariantCulture;
+            var result = await webClient.GetAsync<string>("Test/GetQueryDecimal", query).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString(CultureInfo.InvariantCulture), result);
+        }
+
+        [Fact]
+        public async Task Get_SendHeader()
+        {
+            var expected = "headerValue";
+            var headers = new Dictionary<string, object> { { "test_header", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            var result = await webClient.GetAsync<string>("Test/GetReturnHeaderValue", headers: headers).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task Post_SendHeader()
+        {
+            var expected = "headerValue";
+            var headers = new Dictionary<string, object> { { "test_header", expected } };
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            var result = await webClient.PostAsync<string>("Test/PostReturnHeaderValue", headers: headers).ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task Get_String_WithOffset()
+        {
+            var webClient = new WebClient(_appLogger, _hostUrl + "/Test");
+            var result = await webClient.GetAsync<string>("GetString").ConfigureAwait(false);
+
+            Assert.Equal("GetString", result);
+        }
+
+        [Fact]
+        public async Task Post_String_WithOffset()
+        {
+            var webClient = new WebClient(_appLogger, _hostUrl + "/Test");
+            var result = await webClient.PostAsync<string>("PostString").ConfigureAwait(false);
+
+            Assert.Equal("PostString", result);
         }
 
         public void Dispose()

--- a/tests/Test.bgTeam.Web/WebClientUnitTests.cs
+++ b/tests/Test.bgTeam.Web/WebClientUnitTests.cs
@@ -1,0 +1,122 @@
+﻿using bgTeam;
+using bgTeam.Impl;
+using bgTeam.Web.Impl;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Formatters.Json;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Test.bgTeam.Web
+{
+    public sealed class WebClientUnitTests : IDisposable
+    {
+        private bool _disposed = false;
+        private string _hostUrl;
+        private IWebHost _host;
+        private Task _hostTask;
+        private IAppLogger _appLogger;
+        private CancellationTokenSource _token;
+
+        public WebClientUnitTests()
+        {
+            _hostUrl = "http://localhost:19876";
+            _appLogger = new AppLoggerDefault();
+            _token = new CancellationTokenSource();
+
+            _host = new WebHostBuilder()
+                .UseKestrel()
+                .ConfigureServices(s =>
+                {
+                    s.AddMvcCore()
+                    .AddFormatterMappings()
+                    .AddJsonOptions(opt => opt.SerializerSettings.Formatting = Newtonsoft.Json.Formatting.Indented)
+                    .AddJsonFormatters();
+                })
+                .Configure(app =>
+                {
+                    app.UseMvc();
+                })
+                .UseUrls(_hostUrl)
+                .Build();
+
+            _hostTask = _host.RunAsync(_token.Token);
+        }
+
+        [Fact]
+        public async Task Get_String()
+        {
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            var result = await webClient.GetAsync<string>("Test/GetString").ConfigureAwait(false);
+
+            Assert.Equal("GetString", result);
+        }
+
+        [Fact]
+        public async Task Post_String()
+        {
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            var result = await webClient.PostAsync<string>("Test/PostString").ConfigureAwait(false);
+
+            Assert.Equal("PostString", result);
+        }
+
+        [Fact]
+        public async Task Post_NullString()
+        {
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            var result = await webClient.PostAsync<string>("Test/PostNullString").ConfigureAwait(false);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Post_ArrayString()
+        {
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            var result = await webClient.PostAsync<string[]>("Test/PostArrayString").ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.NotEmpty(result);
+        }
+
+        [Fact]
+        public async Task Post_EmptyArrayString()
+        {
+            var webClient = new WebClient(_appLogger, _hostUrl);
+            var result = await webClient.PostAsync<string[]>("Test/PostEmptyArrayString").ConfigureAwait(false);
+
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _token?.Cancel();
+                _host?.Dispose();
+            }
+
+            _disposed = true;
+        }
+    }
+}


### PR DESCRIPTION
Updates:
1. If outer server return empty array like this '[]' WebClient return empty array too
2. Fixed null reference exception at check 'CharSet' header
3. Added culture to QueryString build in BuildUrl function
4. 'url' in constructor may be 'null'
5. Fixed URL offset in post request